### PR TITLE
Reset stored item on input change

### DIFF
--- a/library.c
+++ b/library.c
@@ -86,11 +86,15 @@ static int ItemChange(vlc_object_t *p_this, const char *psz_var,
     {
         var_DelCallback(p_sys->p_input, "intf-event", PlayingChange, p_intf);
         vlc_object_release(p_sys->p_input);
+        p_sys->p_item = NULL;
         p_sys->p_input = NULL;
     }
 
     if (p_input == NULL)
+    {
+        p_sys->p_item = NULL;
         return VLC_SUCCESS;
+    }
 
     input_item_t *p_item = input_GetItem(p_input);
     if (p_item == NULL)


### PR DESCRIPTION
## Summary
- clear the stored previous item whenever the input thread is released or missing
- ensure PlayingChange can correctly detect new items after input changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd809ce90832f95d0c9931dfa6631)