### PR TITLE
Free interface state on close

### DIFF
--- a/library.c
+++ b/library.c
@@ -64,9 +64,12 @@ static void Close(vlc_object_t *p_this)
     var_DelCallback(pl_Get(p_intf), "input-current", ItemChange, p_intf);
     if (p_sys->p_input != NULL)
     {
-//        var_DelCallback(p_sys->p_input, "intf-event", PlayingChange, p_intf);
+        var_DelCallback(p_sys->p_input, "intf-event", PlayingChange, p_intf);
         vlc_object_release(p_sys->p_input);
+        p_sys->p_input = NULL;
     }
+    free(p_sys);
+    p_intf->p_sys = NULL;
 }
 
 /*****************************************************************************


### PR DESCRIPTION
## Summary
- remove the intf-event callback before releasing the cached input thread
- clear the input thread pointer and free the interface state during close

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd808f1c0832fbc3f37cb65969a88)