### PR TITLE
Align module string with plugin name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(
         ${VLC_INCLUDE_DIR}/plugins
 )
 
-add_definitions(-DMODULE_STRING=\"xattrplaystat\")
+add_definitions(-DMODULE_STRING=\"xattrplaying_plugin\")
 add_definitions(-D__PLUGIN__)
 add_definitions(-D_REENTRANT)
 add_definitions(-D_THREAD_SAFE)

--- a/library.c
+++ b/library.c
@@ -11,6 +11,10 @@
 #include <sys/types.h>
 #include <sys/xattr.h>
 
+#ifndef MODULE_STRING
+#define MODULE_STRING "xattrplaying_plugin"
+#endif
+
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif


### PR DESCRIPTION
## Summary
- set MODULE_STRING to xattrplaying_plugin to match the built module name
- add a fallback MODULE_STRING definition in library.c so exported descriptors use the correct identifier

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7fc0708832f88c54abdb37fb0ae)