### PR TITLE
Add install rule and document cmake install usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ find_library(VLC_PULSE_PATH NAMES vlc_pulse
 get_filename_component(VLC_INSTALL_DIR "${VLC_PULSE_PATH}" DIRECTORY )
 message(STATUS "VLC_INSTALL_DIR: ${VLC_INSTALL_DIR} from ${VLC_PULSE_PATH}")
 
+set(VLC_PLUGIN_INSTALL_DIR "${VLC_INSTALL_DIR}/plugins/misc" CACHE PATH
+        "Installation directory for the VLC misc plugin")
+
 # Set the source files for the extension
 set(SOURCES
         library.c
@@ -44,10 +47,10 @@ target_link_libraries(xattrplaying_plugin ${VLC_LIBRARY})
 # Set the output directory for the shared library
 set_target_properties(xattrplaying_plugin PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib")
 
-## Set installation directory for the shared library
-#install(TARGETS xattrplaying_plugin LIBRARY DESTINATION ${VLC_INSTALL_DIR}/plugins/misc/)
-#
-## Optionally: Copy the plugin to VLC plugins directory for development/testing
+# Set installation directory for the shared library
+install(TARGETS xattrplaying_plugin LIBRARY DESTINATION "${VLC_PLUGIN_INSTALL_DIR}")
+
+# Optionally: Copy the plugin to VLC plugins directory for development/testing
 #add_custom_command(TARGET xattrplaying_plugin POST_BUILD
 #        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:xattrplaying_plugin> ${VLC_INSTALL_DIR}/plugins/$<TARGET_FILE_NAME:xattrplaying_plugin>
 #)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Currently for any system that supports `setxattr` and `getxattr` which AFAIK is 
 
 Currently I'm using: (To build and install)
 ```
-cmake --build ./cmake-build-debug --target all -j 14 && sudo cp -vf "./lib/libxattrplaying_plugin.so" "/usr/lib64/vlc/plugins/misc/libxattrplaying_plugin.so"
+cmake --build ./cmake-build-debug --target all -j 14
+sudo cmake --install ./cmake-build-debug
 ```
+The install step installs `libxattrplaying_plugin.so` into `${VLC_INSTALL_DIR}/plugins/misc` by default.
+You can override this by setting `-DVLC_PLUGIN_INSTALL_DIR=/your/custom/path` when configuring CMake.
 
 Requirements:
 * VLC headers
@@ -29,4 +32,3 @@ Requirements:
 You will need to enable it in the settings once you have placed it in the correct directory:
 
 ![Screenshot_20240615_221813.png](doc/Screenshot_20240615_221813.png)
-


### PR DESCRIPTION
## Summary
- add configurable install destination for the VLC xattr plugin and install rule
- document using `cmake --install` with the new plugin install directory override

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7fffa68832faa994594bb6a21ca)