### PR TITLE
Extract URI decoding helpers and add unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(VLC_PLUGIN_INSTALL_DIR "${VLC_INSTALL_DIR}/plugins/misc" CACHE PATH
 # Set the source files for the extension
 set(SOURCES
         library.c
+        tag_utils.c
 )
 
 # Find VLC libraries and headers
@@ -83,6 +84,15 @@ set_target_properties(xattrplaying_plugin PROPERTIES LIBRARY_OUTPUT_DIRECTORY "$
 
 # Set installation directory for the shared library
 install(TARGETS xattrplaying_plugin LIBRARY DESTINATION "${VLC_PLUGIN_INSTALL_DIR}")
+
+enable_testing()
+
+add_executable(tag_utils_tests
+        tests/tag_utils_tests.c
+        tag_utils.c
+        tag_utils.h)
+target_link_libraries(tag_utils_tests PRIVATE m)
+add_test(NAME tag_utils_tests COMMAND tag_utils_tests)
 
 # Optionally: Copy the plugin to VLC plugins directory for development/testing
 #add_custom_command(TARGET xattrplaying_plugin POST_BUILD

--- a/tag_utils.c
+++ b/tag_utils.c
@@ -1,0 +1,104 @@
+#include "tag_utils.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int hex_value(char c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F')
+        return 10 + (c - 'A');
+    return -1;
+}
+
+bool decode_percent_sequence(const char *p_src, char *p_decoded)
+{
+    if (p_src == NULL || p_decoded == NULL)
+        return false;
+
+    if (p_src[0] != '%' || !isxdigit((unsigned char)p_src[1]) || !isxdigit((unsigned char)p_src[2]))
+        return false;
+
+    int hi = hex_value(p_src[1]);
+    int lo = hex_value(p_src[2]);
+    if (hi < 0 || lo < 0)
+        return false;
+
+    *p_decoded = (char)((hi << 4) | lo);
+    return true;
+}
+
+void url_decode_inplace(char *p_str)
+{
+    if (p_str == NULL)
+        return;
+
+    char *p_read = p_str;
+    char *p_write = p_str;
+
+    while (*p_read != '\0') {
+        if (*p_read == '%' && p_read[1] != '\0' && p_read[2] != '\0') {
+            char decoded;
+            if (decode_percent_sequence(p_read, &decoded)) {
+                *p_write++ = decoded;
+                p_read += 3;
+                continue;
+            }
+        }
+        *p_write++ = *p_read++;
+    }
+
+    *p_write = '\0';
+}
+
+char *xdg_tags_append_if_missing(const char *existing_tags, const char *new_tag,
+                                 bool *out_added)
+{
+    if (out_added)
+        *out_added = false;
+
+    if (new_tag == NULL || *new_tag == '\0')
+        return NULL;
+
+    if (existing_tags == NULL || *existing_tags == '\0') {
+        char *result = strdup(new_tag);
+        if (result && out_added)
+            *out_added = true;
+        return result;
+    }
+
+    const size_t existing_len = strlen(existing_tags);
+    const size_t new_len = strlen(new_tag);
+
+    const char *cursor = existing_tags;
+    while (*cursor != '\0') {
+        const char *next_delim = strchr(cursor, ',');
+        size_t token_len = next_delim ? (size_t)(next_delim - cursor) : strlen(cursor);
+        if (token_len == new_len && strncmp(cursor, new_tag, new_len) == 0) {
+            char *result = strndup(existing_tags, existing_len);
+            return result;
+        }
+        if (!next_delim)
+            break;
+        cursor = next_delim + 1;
+    }
+
+    size_t combined_len = existing_len + 1 /* comma */ + new_len + 1 /* NUL */;
+    char *result = malloc(combined_len);
+    if (result == NULL)
+        return NULL;
+
+    memcpy(result, existing_tags, existing_len);
+    result[existing_len] = ',';
+    memcpy(result + existing_len + 1, new_tag, new_len);
+    result[combined_len - 1] = '\0';
+
+    if (out_added)
+        *out_added = true;
+
+    return result;
+}

--- a/tag_utils.h
+++ b/tag_utils.h
@@ -1,0 +1,35 @@
+#ifndef TAG_UTILS_H
+#define TAG_UTILS_H
+
+#include <stdbool.h>
+
+/**
+ * Decode a percent-encoded triplet (e.g. "%20") into its byte value.
+ *
+ * \param p_src Pointer to the beginning of the percent sequence.
+ * \param p_decoded Output for the decoded character when decoding succeeds.
+ * \return true when the sequence is valid and was decoded, false otherwise.
+ */
+bool decode_percent_sequence(const char *p_src, char *p_decoded);
+
+/**
+ * Decode percent-encoded sequences inside the given string in place.
+ * The function stops at the first null terminator and always leaves the
+ * string null-terminated.
+ */
+void url_decode_inplace(char *p_str);
+
+/**
+ * Ensure that \p new_tag exists inside the comma-separated list in
+ * \p existing_tags. The returned buffer must be freed by the caller.
+ *
+ * \param existing_tags Existing comma-separated tag list (may be NULL or empty).
+ * \param new_tag Tag to append when missing.
+ * \param out_added Optional output set to true when the tag was appended.
+ * \return Newly allocated string containing the resulting tag list, or NULL on
+ *         allocation failure.
+ */
+char *xdg_tags_append_if_missing(const char *existing_tags, const char *new_tag,
+                                 bool *out_added);
+
+#endif // TAG_UTILS_H

--- a/tests/tag_utils_tests.c
+++ b/tests/tag_utils_tests.c
@@ -1,0 +1,75 @@
+#include "../tag_utils.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void test_decode_percent_sequence_valid(void)
+{
+    char decoded = '\0';
+    assert(decode_percent_sequence("%20", &decoded));
+    assert(decoded == ' ');
+
+    assert(decode_percent_sequence("%2F", &decoded));
+    assert(decoded == '/');
+}
+
+static void test_decode_percent_sequence_invalid(void)
+{
+    char decoded = 'x';
+    assert(!decode_percent_sequence("20%", &decoded));
+    assert(decoded == 'x');
+
+    assert(!decode_percent_sequence("%2Z", &decoded));
+    assert(decoded == 'x');
+
+    assert(!decode_percent_sequence("%", &decoded));
+    assert(decoded == 'x');
+}
+
+static void test_url_decode_inplace(void)
+{
+    char path[] = "file%3A%2F%2Ftmp%2Fvideo%20file.mp4";
+    url_decode_inplace(path);
+    assert(strcmp(path, "file://tmp/video file.mp4") == 0);
+
+    char no_encoding[] = "plain_text";
+    url_decode_inplace(no_encoding);
+    assert(strcmp(no_encoding, "plain_text") == 0);
+}
+
+static void test_xdg_tags_append_if_missing(void)
+{
+    bool added = false;
+    char *result = xdg_tags_append_if_missing("alpha,beta", "gamma", &added);
+    assert(result != NULL);
+    assert(strcmp(result, "alpha,beta,gamma") == 0);
+    assert(added);
+    free(result);
+
+    added = false;
+    result = xdg_tags_append_if_missing("alpha,beta", "beta", &added);
+    assert(result != NULL);
+    assert(strcmp(result, "alpha,beta") == 0);
+    assert(!added);
+    free(result);
+
+    added = false;
+    result = xdg_tags_append_if_missing(NULL, "first", &added);
+    assert(result != NULL);
+    assert(strcmp(result, "first") == 0);
+    assert(added);
+    free(result);
+}
+
+int main(void)
+{
+    test_decode_percent_sequence_valid();
+    test_decode_percent_sequence_invalid();
+    test_url_decode_inplace();
+    test_xdg_tags_append_if_missing();
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract URL decoding and tag appending logic into reusable helpers
- add unit tests validating percent decoding, URL decoding, and tag list updates
- integrate new helper sources and tests into CMake configuration

## Testing
- cc -I. tests/tag_utils_tests.c tag_utils.c -o /tmp/tag_utils_tests && /tmp/tag_utils_tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f687f3814832fa43207895214bacf)