### PR TITLE
Use multiarch plugin install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.28)
 project(xattrplaying_plugin C)
 
+include(GNUInstallDirs)
+
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
     pkg_check_modules(VLC QUIET libvlc)
@@ -15,6 +17,8 @@ find_library(VLC_PULSE_PATH NAMES vlc_pulse
             /usr/lib64
             /usr/local/lib
             /usr/local/lib64
+            ${CMAKE_INSTALL_LIBDIR}
+            ${CMAKE_INSTALL_FULL_LIBDIR}
         PATH_SUFFIXES "vlc"
         NO_CACHE)
 if(VLC_PULSE_PATH)
@@ -22,6 +26,9 @@ if(VLC_PULSE_PATH)
     message(STATUS "VLC_INSTALL_DIR: ${VLC_INSTALL_DIR} from ${VLC_PULSE_PATH}")
 endif()
 
+if(NOT VLC_INSTALL_DIR)
+    set(VLC_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/vlc")
+endif()
 set(VLC_PLUGIN_INSTALL_DIR "${VLC_INSTALL_DIR}/plugins/misc" CACHE PATH
         "Installation directory for the VLC misc plugin")
 
@@ -40,14 +47,14 @@ find_path(VLC_INCLUDE_DIR vlc_common.h
 find_library(VLC_LIBVLC_LIBRARY
         NAMES vlc libvlc
         HINTS ${VLC_LIBRARY_DIRS}
-        PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
+        PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 ${CMAKE_INSTALL_LIBDIR} ${CMAKE_INSTALL_FULL_LIBDIR}
         REQUIRED
 )
 
 find_library(VLC_VLCCORE_LIBRARY
         NAMES vlccore libvlccore
         HINTS ${VLC_LIBRARY_DIRS}
-        PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
+        PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 ${CMAKE_INSTALL_LIBDIR} ${CMAKE_INSTALL_FULL_LIBDIR}
         REQUIRED
 )
 

--- a/debian/libxattrplaying_plugin.install
+++ b/debian/libxattrplaying_plugin.install
@@ -1,1 +1,1 @@
-usr/lib64/vlc/plugins/misc/libxattrplaying_plugin.so
+usr/lib/$(DEB_HOST_MULTIARCH)/vlc/plugins/misc/libxattrplaying_plugin.so


### PR DESCRIPTION
## Summary
- default the CMake VLC plugin install directory to the system multiarch libdir when a VLC install path is not detected
- add multiarch-aware library search paths for VLC components during configuration
- install the Debian package payload into the multiarch VLC plugin directory

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6abc5bc4832fb1c95ba6d0b7186d)