### PR TITLE
Add CI workflow with distro containers and docker build helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-analyze:
+    name: Build and analyze (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-24.04
+            image: ubuntu:24.04
+            install: |
+              set -eux
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                build-essential \
+                clang \
+                clang-tidy \
+                cppcheck \
+                cmake \
+                git \
+                pkg-config \
+                libvlc-dev \
+                libvlccore-dev \
+                vlc-plugin-base
+          - label: fedora-40
+            image: fedora:40
+            install: |
+              set -eux
+              dnf -y update
+              dnf -y install \
+                @development-tools \
+                clang-tools-extra \
+                cppcheck \
+                cmake \
+                git \
+                pkg-config \
+                vlc-devel
+    steps:
+      - name: Install system dependencies
+        run: ${{ matrix.install }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Build
+        run: cmake --build build --config RelWithDebInfo
+
+      - name: Run unit tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Run clang-tidy
+        run: clang-tidy -p build library.c tag_utils.c
+
+      - name: Run cppcheck
+        run: cppcheck --enable=warning,performance,style --std=c11 --inline-suppr --suppress=missingIncludeSystem --project=build/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.28)
 project(xattrplaying_plugin C)
 
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+include(CTest)
+
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
     pkg_check_modules(VLC QUIET libvlc)
@@ -85,14 +90,14 @@ set_target_properties(xattrplaying_plugin PROPERTIES LIBRARY_OUTPUT_DIRECTORY "$
 # Set installation directory for the shared library
 install(TARGETS xattrplaying_plugin LIBRARY DESTINATION "${VLC_PLUGIN_INSTALL_DIR}")
 
-enable_testing()
-
-add_executable(tag_utils_tests
-        tests/tag_utils_tests.c
-        tag_utils.c
-        tag_utils.h)
-target_link_libraries(tag_utils_tests PRIVATE m)
-add_test(NAME tag_utils_tests COMMAND tag_utils_tests)
+if(BUILD_TESTING)
+    add_executable(tag_utils_tests
+            tests/tag_utils_tests.c
+            tag_utils.c
+            tag_utils.h)
+    target_link_libraries(tag_utils_tests PRIVATE m)
+    add_test(NAME tag_utils_tests COMMAND tag_utils_tests)
+endif()
 
 # Optionally: Copy the plugin to VLC plugins directory for development/testing
 #add_custom_command(TARGET xattrplaying_plugin POST_BUILD

--- a/ci/docker/Dockerfile.fedora-40
+++ b/ci/docker/Dockerfile.fedora-40
@@ -1,0 +1,23 @@
+FROM fedora:40
+
+RUN set -eux; \
+    dnf -y update; \
+    dnf -y install \
+        @development-tools \
+        clang-tools-extra \
+        cppcheck \
+        cmake \
+        git \
+        pkg-config \
+        vlc-devel; \
+    dnf clean all
+
+WORKDIR /workspace/vlc-xattr-plugin
+
+COPY . /workspace/vlc-xattr-plugin
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
+    cmake --build build --config RelWithDebInfo && \
+    ctest --test-dir build --output-on-failure && \
+    clang-tidy -p build library.c tag_utils.c && \
+    cppcheck --enable=warning,performance,style --std=c11 --inline-suppr --suppress=missingIncludeSystem --project=build/compile_commands.json

--- a/ci/docker/Dockerfile.ubuntu-24.04
+++ b/ci/docker/Dockerfile.ubuntu-24.04
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        clang-tidy \
+        cppcheck \
+        cmake \
+        git \
+        pkg-config \
+        libvlc-dev \
+        libvlccore-dev \
+        vlc-plugin-base; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/vlc-xattr-plugin
+
+COPY . /workspace/vlc-xattr-plugin
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
+    cmake --build build --config RelWithDebInfo && \
+    ctest --test-dir build --output-on-failure && \
+    clang-tidy -p build library.c tag_utils.c && \
+    cppcheck --enable=warning,performance,style --std=c11 --inline-suppr --suppress=missingIncludeSystem --project=build/compile_commands.json

--- a/ci/docker/build.sh
+++ b/ci/docker/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to run these builds" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+for distro in ubuntu-24.04 fedora-40; do
+  docker build -f "${SCRIPT_DIR}/Dockerfile.${distro}" -t "vlc-xattr-plugin:${distro}" "${ROOT_DIR}"
+done


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and tests the plugin inside Ubuntu and Fedora containers with clang-tidy and cppcheck
- set the C standard and test gating via CTest so unit tests run consistently in CI
- provide Dockerfiles and a helper script to reproduce the CI build and analysis locally across the two target distros

## Testing
- ⚠️ `docker run --rm -v "$PWD":/work -w /work ubuntu:24.04 bash -lc "set -euo pipefail; export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install -y --no-install-recommends build-essential clang clang-tidy cppcheck cmake git pkg-config libvlc-dev libvlccore-dev vlc-plugin-base; cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON; cmake --build build; ctest --test-dir build --output-on-failure; clang-tidy -p build library.c tag_utils.c; cppcheck --enable=warning,performance,style --std=c11 --inline-suppr --suppress=missingIncludeSystem --project=build/compile_commands.json"` (failed: docker not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6b1db534832f956003df00d43c57)