### PR TITLE
Add configurable tagging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,20 @@ VLC looks for interface plugins under the `vlc/plugins/misc` subtree of its plug
 You will need to enable it in the settings once you have placed it in the correct directory:
 
 ![Screenshot_20240615_221813.png](doc/Screenshot_20240615_221813.png)
+
+## Module options
+
+The plugin exposes a few options under *Tools → Preferences → Interface → Control interfaces*:
+
+* **Enable tagging** (`xattr-tagging-enabled`, default: on): master switch to write `user.xdg.tags`.
+* **Tag name** (`xattr-tag-name`, default: `seen`): value appended to `user.xdg.tags`.
+* **Skip paths** (`xattr-skip-paths`): comma or newline separated list of absolute path prefixes to skip (e.g., `/tmp,/mnt/ramdisk`).
+
+Set the options via the GUI or by adding the following lines to your `vlcrc`:
+
+```
+lua-intf=xattrplaying_plugin
+xattr-tagging-enabled=1
+xattr-tag-name=seen
+xattr-skip-paths=/tmp,/mnt/ramdisk
+```


### PR DESCRIPTION
## Summary
- add module options to enable/disable tagging, configure the tag name, and skip path prefixes
- document the new options in the code comments and README usage section
- guard xattr writes when tagging is disabled, tag name is empty, or paths match the skip list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6c944ec8832fad9c188da45828f8)